### PR TITLE
Fix index mapping in readAttendance() method

### DIFF
--- a/Scheduler.java
+++ b/Scheduler.java
@@ -97,7 +97,7 @@ public class Scheduler {
 
         for (int i = 1; i < students.size(); i++) { // i = 1 since first index is date
             if (splitLine[i].equals("y")) {
-                attendingStudents.add(students.get(i)); // Add all students from last recorded attendance
+                attendingStudents.add(students.get(i - 1)); // Add all students from last recorded attendance
             }
         }
     }


### PR DESCRIPTION
This pull request resolves issue #2. 
Corrected the index mapping in the readAttendance() loop to use i-1 instead of i. 
This ensures that attendance data from the CSV file is correctly aligned with the student list.